### PR TITLE
Replicate website ui for navbar and sidebar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import DashboardLayout from './layouts/DashboardLayout.jsx'
 
-function  App() {
+function App() {
   return (
-    <div className='h-screen w-screen bg-slate-200 flex items-center justify-center'c>App</div>
+    <DashboardLayout>
+      <div className="p-6">Dashboard content goes here.</div>
+    </DashboardLayout>
   )
 }
 
-export default  App
+export default App

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+function Navbar() {
+  return (
+    <header className="sticky top-0 z-40 h-14 border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <div className="mx-auto flex h-14 max-w-screen-2xl items-center gap-3 px-4">
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-600 to-cyan-500" />
+          <span className="font-semibold tracking-tight">SellSynth</span>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <button className="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm hover:bg-slate-50">Upgrade</button>
+          <button className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 shadow-sm hover:bg-slate-50">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-bell">
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
+              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/>
+            </svg>
+          </button>
+          <div className="h-8 w-8 rounded-full bg-slate-200" />
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export default Navbar

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+
+const navItems = [
+  { label: 'Dashboard', icon: 'home' },
+  { label: 'Leads', icon: 'users' },
+  { label: 'Campaigns', icon: 'target' },
+  { label: 'Scripts', icon: 'file-text' },
+  { label: 'Analytics', icon: 'chart' },
+  { label: 'Schedule', icon: 'calendar' },
+  { label: 'Settings', icon: 'settings' },
+]
+
+function Icon({ name, className }) {
+  switch (name) {
+    case 'home':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><path d="M3 9l9-7 9 7"/><path d="M9 22V12h6v10"/></svg>
+      )
+    case 'users':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+      )
+    case 'target':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
+      )
+    case 'file-text':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg>
+      )
+    case 'chart':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg>
+      )
+    case 'calendar':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+      )
+    case 'settings':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V22a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 8 20.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4 16.82a1.65 1.65 0 0 0-1.51-1H2a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 3.6 10a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 8 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09A1.65 1.65 0 0 0 15 3.6a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 20.4 10c0 .26.03.52.09.77"/></svg>
+      )
+    default:
+      return null
+  }
+}
+
+function Sidebar() {
+  return (
+    <aside className="fixed inset-y-0 left-0 z-30 hidden w-60 border-r bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60 md:block">
+      <div className="flex h-14 items-center gap-2 border-b px-4">
+        <div className="h-7 w-7 rounded-md bg-gradient-to-br from-blue-600 to-cyan-500" />
+        <span className="text-sm font-semibold tracking-tight">SellSynth</span>
+      </div>
+      <nav className="flex flex-col gap-1 p-2">
+        {navItems.map((item) => (
+          <button key={item.label} className="group inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm text-slate-700 hover:bg-slate-100 hover:text-slate-900">
+            <Icon name={item.icon} className="h-4 w-4 text-slate-500 group-hover:text-slate-700" />
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </nav>
+      <div className="absolute bottom-0 left-0 right-0 border-t p-3">
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-full bg-slate-200" />
+          <div className="flex-1">
+            <div className="text-sm font-medium">John Doe</div>
+            <div className="text-xs text-slate-500">Free plan</div>
+          </div>
+          <button className="rounded-md border px-2 py-1 text-xs hover:bg-slate-50">Logout</button>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+export default Sidebar

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import Navbar from '../components/Navbar.jsx'
+import Sidebar from '../components/Sidebar.jsx'
+
+function DashboardLayout({ children }) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <Navbar />
+      <Sidebar />
+      <div className="md:pl-60 pt-14">
+        <main className="mx-auto max-w-screen-2xl p-4 md:p-6 lg:p-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default DashboardLayout


### PR DESCRIPTION
Implement Navbar and Sidebar components and integrate them into a DashboardLayout to replicate the SellSynth dashboard UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7986f5b-a1bc-473f-b4c9-d57c9b08399a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7986f5b-a1bc-473f-b4c9-d57c9b08399a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

